### PR TITLE
ApolloProvider

### DIFF
--- a/src/ApolloProvider.tsx
+++ b/src/ApolloProvider.tsx
@@ -1,0 +1,60 @@
+/// <reference path="../typings/main.d.ts" />
+
+import {
+    Component,
+    PropTypes,
+    Children,
+} from 'react';
+
+import {
+    Provider,
+} from 'react-redux';
+
+import {
+    Store
+} from 'redux';
+
+import ApolloClient from 'apollo-client';
+
+export declare interface ProviderProps {
+    store?: Store<any>;
+    client: ApolloClient;
+}
+
+export default class ApolloProvider extends Component<ProviderProps, any> {
+    static propTypes = {
+        store: PropTypes.shape({
+            subscribe: PropTypes.func.isRequired,
+            dispatch: PropTypes.func.isRequired,
+            getState: PropTypes.func.isRequired,
+        }),
+        client: PropTypes.object.isRequired,
+        children: PropTypes.element.isRequired,
+    };
+
+    static childContextTypes = {
+        store: PropTypes.object.isRequired,
+        client: PropTypes.object.isRequired,
+    };
+
+    public store: Store<any>;
+    public client: ApolloClient;
+
+    getChildContext() {
+        const { client } = this.props;
+        return {
+            client
+        }
+    }
+    render() {
+        const { store, children } = this.props;
+        return (
+            <Provider
+                store={store}
+            >
+                {children}
+            </Provider>
+        )
+    }
+
+}

--- a/src/ApolloProvider.tsx
+++ b/src/ApolloProvider.tsx
@@ -1,9 +1,10 @@
 /// <reference path="../typings/main.d.ts" />
-
+/* tslint:disable:no-unused-variable */
+import * as React from 'react';
+/* tslint:enable:no-unused-variable */
 import {
     Component,
     PropTypes,
-    Children,
 } from 'react';
 
 import {
@@ -11,13 +12,14 @@ import {
 } from 'react-redux';
 
 import {
-    Store
+    Store,
 } from 'redux';
+
 
 import ApolloClient from 'apollo-client';
 
 export declare interface ProviderProps {
-    store?: Store<any>;
+    store: Store<any>;
     client: ApolloClient;
 }
 
@@ -43,18 +45,17 @@ export default class ApolloProvider extends Component<ProviderProps, any> {
     getChildContext() {
         const { client } = this.props;
         return {
-            client
-        }
+            client,
+        };
     }
+
     render() {
         const { store, children } = this.props;
         return (
-            <Provider
-                store={store}
-            >
+            <Provider store={store}>
                 {children}
             </Provider>
-        )
+        );
     }
 
 }

--- a/src/ApolloProvider.tsx
+++ b/src/ApolloProvider.tsx
@@ -35,7 +35,6 @@ export default class ApolloProvider extends Component<ProviderProps, any> {
     };
 
     static childContextTypes = {
-        store: PropTypes.object.isRequired,
         client: PropTypes.object.isRequired,
     };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import Provider from './Provider';
 import connect from './connect';
+import ApolloProvider from './ApolloProvider';
 
-export { Provider, connect };
+export { Provider, connect, ApolloProvider };

--- a/test/ApolloProvider.tsx
+++ b/test/ApolloProvider.tsx
@@ -7,6 +7,7 @@ import { createStore } from 'redux';
 
 declare function require(name: string);
 import chaiEnzyme = require('chai-enzyme');
+import * as TestUtils from 'react-addons-test-utils';
 
 chai.use(chaiEnzyme()); // Note the invocation at the end
 const { expect } = chai;
@@ -15,19 +16,28 @@ import ApolloProvider from '../src/ApolloProvider';
 
 import ApolloClient from 'apollo-client';
 
+interface ChildContext {
+    store: Object;
+    client: Object;
+}
+
 describe('<ApolloProvider /> Component', () => {
 
     class Child extends React.Component<any, { store: any, client: any}> {
+        static contextTypes: React.ValidationMap<any> =  {
+            client:  React.PropTypes.object.isRequired,
+            store: React.PropTypes.object.isRequired,
+        };
+        context: ChildContext;
         render() {
             return <div />;
         }
     }
 
     const client = new ApolloClient();
+    const store = createStore(() => ({}));
 
     it('should render children components', () => {
-        const store = createStore(() => ({}));
-
         const wrapper = shallow(
             <ApolloProvider store={store} client={client}>
                 <div className='unique' />
@@ -38,8 +48,6 @@ describe('<ApolloProvider /> Component', () => {
     });
 
      it('should throw if rendered without a child component', () => {
-       const store = createStore(() => ({}));
-
        try {
          shallow(
            <ApolloProvider store={store} client={client} />
@@ -49,4 +57,18 @@ describe('<ApolloProvider /> Component', () => {
        }
 
      });
+
+    it('should add the client to the child context', () => {
+        const tree = TestUtils.renderIntoDocument(
+            <ApolloProvider store={store} client={client}>
+                <Child />
+            </ApolloProvider>
+        ) as React.Component<any, any>;
+
+        const child = TestUtils.findRenderedComponentWithType(tree, Child);
+        expect(child.context.client).to.deep.equal(client);
+
+    });
 });
+
+

--- a/test/ApolloProvider.tsx
+++ b/test/ApolloProvider.tsx
@@ -1,0 +1,52 @@
+/// <reference path="../typings/main.d.ts" />
+
+import * as React from 'react';
+import * as chai from 'chai';
+import { shallow } from 'enzyme';
+import { createStore } from 'redux';
+
+declare function require(name: string);
+import chaiEnzyme = require('chai-enzyme');
+
+chai.use(chaiEnzyme()); // Note the invocation at the end
+const { expect } = chai;
+
+import ApolloProvider from '../src/ApolloProvider';
+
+import ApolloClient from 'apollo-client';
+
+describe('<ApolloProvider /> Component', () => {
+
+    class Child extends React.Component<any, { store: any, client: any}> {
+        render() {
+            return <div />;
+        }
+    }
+
+    const client = new ApolloClient();
+
+    it('should render children components', () => {
+        const store = createStore(() => ({}));
+
+        const wrapper = shallow(
+            <ApolloProvider store={store} client={client}>
+                <div className='unique' />
+            </ApolloProvider>
+        );
+
+        expect(wrapper.contains(<div className='unique' />)).to.equal(true);
+    });
+
+     it('should throw if rendered without a child component', () => {
+       const store = createStore(() => ({}));
+
+       try {
+         shallow(
+           <ApolloProvider store={store} client={client} />
+         );
+       } catch (e) {
+         expect(e).to.be.instanceof(Error);
+       }
+
+     });
+});


### PR DESCRIPTION
In reference to this issue [#142](https://github.com/apollostack/apollo-client/issues/142)
This PR is the first step of providing Apollo users a direct integration with the Redux library and set of existing tools.

### What are we shipping?

I think to provide a seamless integration into current Redux workflows, exporting an `ApolloProvider` allows us to maintain the Apollo integration a layer above `ReactRedux`'s `Provider` implementation.

### Usage

```js
import React from 'react';
import { render } from 'react-dom';
import { ApolloProvider } from 'react-apollo';
import Store from './store';
import ApolloClient from 'apollo-client';

const client = new ApolloClient();

Meteor.startup(() => {
  render(<ApolloProvider store={Store} client={client}>
    <App />
  </ApolloProvider>, document.getElementById('app'));
});
```

To note: `store` is a required prop

### Benefits
On the surface this change doesn't seem like a big deal. And really it isn't far off then what `react-apollo` ships, but:
1. this allows `react-apollo` to gain upstream changes to the `Provider` component from `react-redux`. 2. helps alleviate confusion between large apps that may be fragmented, meaning they don't have clear component trees e.g. multiple `Providers` who may be confused what `Provider` they are actually using. People don't read 🚨 