### PR TITLE
Performance improvements, and better lifecycle support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,13 @@
 
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 1 or 2 months), so that we can take advantage of SemVer to signify breaking changes from that point on.
 
-### v0.3.2
+### v0.3.4
+
+Bug: Fix bug where state / props weren't accurate when executing mutations.
+Perf: Increase performance by limiting re-renders and re-execution of queries.
+Chore: Split tests to make them easier to maintain.
+
+### v0.3.2 || v0.3.3 (publish fix)
 
 Feature: add `startPolling` and `stopPolling` to the prop object for queries
 Bug: Fix bug where full options were not being passed to watchQuery

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-apollo",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "React data container for Apollo Client",
   "main": "index.js",
   "scripts": {

--- a/src/connect.tsx
+++ b/src/connect.tsx
@@ -46,7 +46,7 @@ export declare interface ConnectOptions {
   options?: IConnectOptions;
   mergeProps?(stateProps: Object, dispatchProps: Object, ownProps: Object): Object;
   mapQueriesToProps?(opts: MapQueriesToPropsOptions): Object; // WatchQueryHandle
-  mapMutationsToProps?(opts: MapQueriesToPropsOptions): Object; // Mutation Handle
+  mapMutationsToProps?(opts: MapMutationsToPropsOptions): Object; // Mutation Handle
 };
 
 const defaultMapQueriesToProps = opts => ({ });

--- a/src/connect.tsx
+++ b/src/connect.tsx
@@ -175,8 +175,9 @@ export default function connect(opts?: ConnectOptions) {
         // to avoid rebinding queries if nothing has changed
         if (!isEqual(this.props, nextProps)) {
           this.haveOwnPropsChanged = true;
-          this.subscribeToAllQueries(nextProps);
           this.createAllMutationHandles(nextProps);
+          this.subscribeToAllQueries(nextProps);
+
         }
       }
 
@@ -367,7 +368,7 @@ export default function connect(opts?: ConnectOptions) {
       createAllMutationHandles(props: any): void {
 
         const mutations = mapMutationsToProps({
-          ownProps: this.props,
+          ownProps: props,
           state: this.store.getState(),
         });
 

--- a/test/connect/mutations.tsx
+++ b/test/connect/mutations.tsx
@@ -370,9 +370,9 @@ describe('mutations', () => {
       networkInterface,
     });
 
-    function mapMutationsToProps() {
+    function mapMutationsToProps({ ownProps }) {
       return {
-        makeListPrivate: ({ ownProps }) => {
+        makeListPrivate: () => {
           expect(ownProps.listId).to.equal('1');
           return {
             mutation,
@@ -441,10 +441,10 @@ describe('mutations', () => {
       networkInterface,
     });
 
-    function mapMutationsToProps() {
+    function mapMutationsToProps({ state }) {
 
       return {
-        makeListPrivate: ({ state }) => {
+        makeListPrivate: () => {
           expect(state.listId).to.equal('1');
           return {
             mutation,
@@ -483,7 +483,7 @@ describe('mutations', () => {
     );
   });
 
-  it('gets the state at muation execution', (done) => {
+  it('gets the correct state at muation execution', (done) => {
 
     const mutation = gql`
       mutation makeListPrivate($listId: ID!) {
@@ -542,9 +542,9 @@ describe('mutations', () => {
       applyMiddleware(client.middleware())
     );
 
-    function mapMutationsToProps() {
+    function mapMutationsToProps({ state }) {
       return {
-        makeListPrivate: ({ state }) => {
+        makeListPrivate: () => {
           expect(state.counter).to.equal(2);
           done();
           return {

--- a/test/connect/queries.tsx
+++ b/test/connect/queries.tsx
@@ -26,6 +26,120 @@ import {
 import connect from '../../src/connect';
 
 describe('queries', () => {
+  it('doesn\'t rerun the query if it doesn\'t change', (done) => {
+    const query = gql`
+      query people($person: Int!) {
+        allPeople(first: $person) {
+          people {
+            name
+          }
+        }
+      }
+    `;
+
+    const data1 = {
+      allPeople: {
+        people: [
+          {
+            name: 'Luke Skywalker',
+          },
+        ],
+      },
+    };
+
+    const data2 = {
+      allPeople: {
+        people: [
+          {
+            name: 'Leia Skywalker',
+          },
+        ],
+      },
+    };
+
+    const variables1 = {
+      person: 1
+    }
+
+    const variables2 = {
+      person: 2
+    }
+
+    const networkInterface = mockNetworkInterface(
+      {
+        request: { query, variables: variables1 },
+        result: { data: data1 },
+      },
+      {
+        request: { query, variables: variables2 },
+        result: { data: data2 },
+      }
+    );
+
+    const client = new ApolloClient({
+      networkInterface,
+    });
+
+    function mapQueriesToProps({ state }) {
+      return {
+        foobar: {
+          query,
+          variables: {
+            person: 1,
+          }
+        },
+      };
+    };
+
+    function counter(state = 1, action) {
+      switch (action.type) {
+        case 'INCREMENT':
+          return state + 1
+        default:
+          return state
+        }
+    }
+
+    // Typscript workaround
+    const apolloReducer = client.reducer() as () => any;
+
+    const store = createStore(
+      combineReducers({
+        counter,
+        apollo: apolloReducer
+      }),
+      applyMiddleware(client.middleware())
+    );
+
+    let hasDispatched = false;
+    let count = 0;
+    @connect({ mapQueriesToProps })
+    class Container extends React.Component<any, any> {
+
+      componentWillReceiveProps(nextProps) {
+        count++;
+        if (nextProps.foobar.allPeople && !hasDispatched) {
+          hasDispatched = true;
+          this.props.dispatch({ type: 'INCREMENT' });
+        }
+      }
+      render() {
+        return <Passthrough {...this.props} />;
+      }
+    };
+
+    const wrapper = mount(
+      <ProviderMock store={store} client={client}>
+        <Container />
+      </ProviderMock>
+    );
+
+    setTimeout(() => {
+      expect(count).to.equal(2);
+      done();
+    }, 250);
+  });
+
   it('binds a query to props', () => {
     const store = createStore(() => ({
       foo: 'bar',
@@ -116,11 +230,12 @@ describe('queries', () => {
     const client = new ApolloClient({
       networkInterface,
     });
-
+    let wrapper;
     let firstRun = true;
     function mapQueriesToProps({ state }) {
       if (!firstRun) {
         expect(state.counter).to.equal(2);
+        wrapper.unmount();
         done();
       } else {
         firstRun = false;
@@ -156,7 +271,120 @@ describe('queries', () => {
       componentWillReceiveProps(nextProps) {
         if (nextProps.people.allPeople && !hasDispatched) {
           hasDispatched = true;
-          console.log("dispatching")
+          this.props.dispatch({ type: 'INCREMENT' });
+        }
+      }
+      render() {
+        return <Passthrough {...this.props} />;
+      }
+    };
+
+    wrapper = mount(
+      <ProviderMock store={store} client={client}>
+        <Container pass='through' baz={50} />
+      </ProviderMock>
+    ) as any;
+
+  });
+
+  it('does rerun the query if it changes', (done) => {
+    const query = gql`
+      query people($person: Int!) {
+        allPeople(first: $person) {
+          people {
+            name
+          }
+        }
+      }
+    `;
+
+    const data1 = {
+      allPeople: {
+        people: [
+          {
+            name: 'Luke Skywalker',
+          },
+        ],
+      },
+    };
+
+    const data2 = {
+      allPeople: {
+        people: [
+          {
+            name: 'Leia Skywalker',
+          },
+        ],
+      },
+    };
+
+    const variables1 = {
+      person: 1
+    }
+
+    const variables2 = {
+      person: 2
+    }
+
+    const networkInterface = mockNetworkInterface(
+      {
+        request: { query, variables: variables1 },
+        result: { data: data1 },
+      },
+      {
+        request: { query, variables: variables2 },
+        result: { data: data2 },
+      }
+    );
+
+    const client = new ApolloClient({
+      networkInterface,
+    });
+
+    let firstRun = true;
+    function mapQueriesToProps({ state }) {
+      return {
+        people: {
+          query,
+          variables: {
+            person: state.counter,
+          }
+        },
+      };
+    };
+
+    function counter(state = 1, action) {
+      switch (action.type) {
+        case 'INCREMENT':
+          return state + 1
+        default:
+          return state
+        }
+    }
+
+    // Typscript workaround
+    const apolloReducer = client.reducer() as () => any;
+
+    const store = createStore(
+      combineReducers({
+        counter,
+        apollo: apolloReducer
+      }),
+      applyMiddleware(client.middleware())
+    );
+
+    let hasDispatched = false;
+    let count = 0;
+    @connect({ mapQueriesToProps })
+    class Container extends React.Component<any, any> {
+      componentDidMount(){
+        count++; // increase for the loading
+      }
+
+      componentWillReceiveProps(nextProps) {
+        count++;
+        if (nextProps.people.allPeople && !hasDispatched) {
+          hasDispatched = true;
           this.props.dispatch({ type: 'INCREMENT' });
         }
       }
@@ -170,6 +398,11 @@ describe('queries', () => {
         <Container pass='through' baz={50} />
       </ProviderMock>
     );
+
+    setTimeout(() => {
+      expect(count).to.equal(3);
+      done();
+    }, 250);
   });
 
   it('stops the query after unmounting', () => {


### PR DESCRIPTION
This PR does a few things (it can be split up if needed).

- [x] Queries re run on when the redux state (aside from apollo) change
- [x] `mapMutationsToProps` rebuild on change
- [x] update Changelog.md
- [x] diff queries before rerunning to see if they have changed

Fixes #41 and #20

cc @stubailo @johnthepink 

