### PR TITLE
set the default loading state on mutations to be false

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 1 or 2 months), so that we can take advantage of SemVer to signify breaking changes from that point on.
 
+### vNext
+
+Bug: Loading state is no longer true on uncalled mutations.
+
 ### v0.3.5
 
 Return promise from the refetch method

--- a/src/connect.tsx
+++ b/src/connect.tsx
@@ -56,6 +56,7 @@ const defaultQueryData = {
   errors: null,
 };
 const defaultMutationData = assign({}, defaultQueryData);
+defaultMutationData.loading = false;
 
 function getDisplayName(WrappedComponent) {
   return WrappedComponent.displayName || WrappedComponent.name || 'Component';

--- a/test/connect/mutations.tsx
+++ b/test/connect/mutations.tsx
@@ -81,7 +81,7 @@ describe('mutations', () => {
     const props = wrapper.find('span').props() as any;
 
     expect(props.makeListPrivate).to.exist;
-    expect(props.makeListPrivate.loading).to.be.true;
+    expect(props.makeListPrivate.loading).to.be.false;
   });
 
   it('should bind multiple mutation keys to props', () => {
@@ -143,9 +143,9 @@ describe('mutations', () => {
     const props = wrapper.find('span').props() as any;
 
     expect(props.makeListPrivate).to.exist;
-    expect(props.makeListPrivate.loading).to.be.true;
+    expect(props.makeListPrivate.loading).to.be.false;
     expect(props.makeListReallyPrivate).to.exist;
-    expect(props.makeListReallyPrivate.loading).to.be.true;
+    expect(props.makeListReallyPrivate.loading).to.be.false;
   });
 
   it('should bind mutation handler to `props.mutations[key]`', () => {
@@ -202,7 +202,7 @@ describe('mutations', () => {
     const props = wrapper.find('span').props() as any;
 
     expect(props.makeListPrivate).to.exist;
-    expect(props.makeListPrivate.loading).to.be.true;
+    expect(props.makeListPrivate.loading).to.be.false;
 
     expect(props.mutations).to.exist;
     expect(props.mutations.makeListPrivate).to.exist;
@@ -263,7 +263,7 @@ describe('mutations', () => {
     const props = wrapper.find('span').props() as any;
 
     expect(props.makeListPrivate).to.exist;
-    expect(props.makeListPrivate.loading).to.be.true;
+    expect(props.makeListPrivate.loading).to.be.false;
 
     expect(props.mutations).to.exist;
     expect(props.mutations.makeListPrivate).to.exist;


### PR DESCRIPTION
Originally queries and mutations pull from the same default values for consistency. It doesn't really make sense that `loading` would be true on mutations until they are called so this PR fixes that.

Original issue and disucssion: #64 