### PR TITLE
Hotfix refetch loading state

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 1 or 2 months), so that we can take advantage of SemVer to signify breaking changes from that point on.
 
+### v.0.3.7
+
+Bug: Reset loading state when a refetched query has returned
+
 ### v0.3.6
 
 Bug: Loading state is no longer true on uncalled mutations.

--- a/src/connect.tsx
+++ b/src/connect.tsx
@@ -335,7 +335,7 @@ export default function connect(opts?: ConnectOptions) {
 
           // only rerender child component if data has changed
           // XXX should we rerender while errors are present?
-          if (!isEqual(oldData, data) || errors) {
+          if (!isEqual(oldData, data) || errors || this.data[key].loading) {
             this.hasQueryDataChanged = true;
           }
 

--- a/test/connect/queries.tsx
+++ b/test/connect/queries.tsx
@@ -1090,6 +1090,94 @@ describe('queries', () => {
     );
   });
 
+  it('resets the loading state after a refetched query even if the data doesn\'t change', (done) => {
+
+    const query = gql`
+      query people {
+        allPeople(first: 1) {
+          people {
+            name
+          }
+        }
+      }
+    `;
+
+    const data1 = {
+      allPeople: {
+        people: [
+          {
+            name: 'Luke Skywalker',
+          },
+        ],
+      },
+    };
+
+    const networkInterface = mockNetworkInterface(
+      {
+        request: { query: query },
+        result: { data: data1 },
+      },
+      {
+        request: { query: query },
+        result: { data: data1 },
+      }
+    );
+
+    const client = new ApolloClient({
+      networkInterface,
+    });
+
+    function mapQueriesToProps() {
+      return {
+        people: { query },
+      };
+    };
+
+    let hasRefetched = false;
+    let hasRefetchedAndReturned = false;
+    @connect({ mapQueriesToProps })
+    class Container extends React.Component<any, any> {
+      componentWillReceiveProps(nextProps) {
+
+        if (hasRefetchedAndReturned) {
+          expect(nextProps.people.loading).to.be.false;
+          done();
+          return;
+        }
+
+        if (hasRefetched) {
+          expect(nextProps.people.loading).to.be.true;
+          hasRefetchedAndReturned = true;
+          return;
+        }
+      }
+
+      componentDidUpdate(prevProps) {
+
+        if (prevProps.people.loading && !this.props.people.loading) {
+
+          if (hasRefetched) {
+            return;
+          }
+
+          hasRefetched = true;
+          this.props.people.refetch()
+          return;
+        }
+
+      }
+      render() {
+        return <Passthrough {...this.props} />;
+      }
+    };
+
+    mount(
+      <ProviderMock client={client}>
+        <Container />
+      </ProviderMock>
+    );
+  });
+
   it('resets the loading state when refetching', (done) => {
     const store = createStore(() => ({
       foo: 'bar',


### PR DESCRIPTION
When a refetched query returned the same data as the original, the loading state wasn't correctly being updated.