### PR TITLE
Provide watchQuery to components via connect.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 1 or 2 months), so that we can take advantage of SemVer to signify breaking changes from that point on.
 
+### vNEXT
+
+Feature: provide add `watchQuery` to components via `connect`
+
 ### v.0.3.8
 
 Bug: Don't use old props on store change change

--- a/src/connect.tsx
+++ b/src/connect.tsx
@@ -487,6 +487,7 @@ export default function connect(opts?: ConnectOptions) {
         let clientProps = {
           mutate: this.client.mutate,
           query: this.client.query,
+          watchQuery: this.client.watchQuery,
         } as any;
 
         if (Object.keys(mutations).length) {

--- a/test/connect/props.tsx
+++ b/test/connect/props.tsx
@@ -107,6 +107,35 @@ describe('props', () => {
 
   });
 
+  it('should pass `ApolloClient.watchQuery` as props.watchQuery', () => {
+    const store = createStore(() => ({ }));
+    const client = new ApolloClient();
+
+    @connect()
+    class Container extends React.Component<any, any> {
+      render() {
+        return <Passthrough {...this.props} />;
+      }
+    };
+
+    const wrapper = mount(
+      <ProviderMock store={store} client={client}>
+        <Container pass='through' baz={50} />
+      </ProviderMock>
+    );
+
+
+    const props = wrapper.find('span').props() as any;
+
+    expect(props.watchQuery).to.exist;
+    try {
+      expect(props.watchQuery()).to.be.instanceof(Promise);
+    } catch (e) {
+      expect(e).to.be.instanceof(TypeError);
+    };
+
+  });
+
   it('should pass mutation methods as props.mutations dictionary', () => {
     const store = createStore(() => ({ }));
 

--- a/test/connect/redux.tsx
+++ b/test/connect/redux.tsx
@@ -64,6 +64,7 @@ describe('redux integration', () => {
     const reduxProps = assign({}, wrapper.find('span').props(), {
       query: undefined,
       mutate: undefined,
+      watchQuery: undefined,
     });
     const apolloProps = apolloWrapper.find('span').props();
 


### PR DESCRIPTION
I was recently looking for a way to subscribe to `watchQuery` directly, rather than through the usual `mapQueriesToProps`, and noticed that, while `query` and `mutate` are passed via `connect`, `watchQuery` is not. This PR changes that.