### PR TITLE
remove typescript declarations from output

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,
-    "declaration": true,
+    "declaration": false,
     "noImplicitAny": false,
     "rootDir": ".",
     "outDir": "lib",


### PR DESCRIPTION
Suggesting to remove typescript declarations from the output. When i try to use this library with typescript it uses the definitions outputted, and they don't work because typings is not included. 

Tried to include typings, but got a lot of errors.

Best would be to include the typings folder in the output?