### PR TITLE
Throw an error if the client is missing

### DIFF
--- a/src/ApolloProvider.tsx
+++ b/src/ApolloProvider.tsx
@@ -16,6 +16,8 @@ import {
 
 import ApolloClient from 'apollo-client';
 
+import invariant = require('invariant');
+
 export declare interface ProviderProps {
   store?: Store<any>;
   client: ApolloClient;
@@ -42,6 +44,13 @@ export default class ApolloProvider extends Component<ProviderProps, any> {
 
   constructor(props, context) {
     super(props, context);
+
+    invariant(
+      props.client,
+      'ApolloClient was not passed a client instance. Make ' +
+      'sure you pass in your client via the "client" prop.'
+    );
+
     this.client = props.client;
 
     if (props.store) {

--- a/test/client/ApolloProvider.tsx
+++ b/test/client/ApolloProvider.tsx
@@ -49,6 +49,19 @@ describe('<ApolloProvider /> Component', () => {
     expect(wrapper.contains(<div className='unique'/>)).to.equal(true);
   });
 
+  it('should require a client', () => {
+    expect(() => {
+      shallow(
+        <ApolloProvider client={undefined}>
+          <div className='unique'/>
+        </ApolloProvider>
+      )
+    }).to.throw(
+      'ApolloClient was not passed a client instance. Make ' +
+      'sure you pass in your client via the "client" prop.'
+    );
+  })
+
   it('should not require a store', () => {
     const wrapper = shallow(
       <ApolloProvider client={client}>


### PR DESCRIPTION
The current error just states that it `"can't read initStore of undefined"`, which is a pretty cryptic error if you're not familiar with the internals of `ApolloProvider`.

This just throws a more friendly error.