### PR TITLE
Point TypeScript users to the root typings file

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.19",
   "description": "React data container for Apollo Client",
   "main": "index.js",
+  "typings": "index.d.ts",
   "scripts": {
     "pretest": "npm run compile",
     "test": "mocha --require ./test/fixtures/setup.js --reporter spec --full-trace --recursive ./lib/test",


### PR DESCRIPTION
AFAIK this should address #77 so that you can just `npm install apollo-react` and have full typings available to TypeScript