### PR TITLE
Upgrade to TypeScript 2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNext
 
+- Feature: Upgrade the version of `typescript` [#229](https://github.com/apollostack/react-apollo/pull/229)
+
 ### v0.5.6
 
 - Bug: Passing immutable to ApolloProvider breaks ssr. `renderToStringWithData` fails to reference the right store.

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "apollo-client": "^0.4.12"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.36",
     "apollo-client": "0.4.13",
     "babel-jest": "^14.1.0",
     "babel-preset-react-native": "^1.9.0",
@@ -88,7 +89,7 @@
     "swapi-graphql": "0.0.4",
     "travis-weigh-in": "^1.0.2",
     "tslint": "^3.6.0",
-    "typescript": "^1.8.9",
+    "typescript": "^2.0.3",
     "typescript-require": "^0.2.9-1",
     "typings": "^0.7.9",
     "uglify-js": "^2.6.2"


### PR DESCRIPTION
As a part of the implementation of #209 we need to upgrade the version of `typescript` because the newest version of `apollo-client` uses it 