### PR TITLE
Support Node 4 for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: node_js
 node_js:
+  - "4"
   - "6"
 
 install:
+  - npm install -g npm@^3
   - npm install -g coveralls
   - npm install
 

--- a/preprocessor.js
+++ b/preprocessor.js
@@ -12,6 +12,7 @@ module.exports = {
         {
           module: tsc.ModuleKind.CommonJS,
           jsx: tsc.JsxEmit.React,
+          target: tsc.ScriptTarget.ES5
         },
         path,
         []


### PR DESCRIPTION
The `npm test` infrastructure seemed to have broken for Node 4, though we still think that the distribution worked (because it targeted ES5 in tsconfig.json).