### PR TITLE
Fix issue with SSR on a mutation wrapping a query

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNext
 
+- Bug: Fix issue with SSR queries running twice when a mutation wraps a query [#274](https://github.com/apollostack/react-apollo/issue/274)
+
+
 ### v0.5.10
 
 - Bug: Fix issue with changing outer props *and not changing variables*, ultimately caused by https://github.com/apollostack/apollo-client/pull/694

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -109,7 +109,7 @@ export function withApollo(WrappedComponent) {
   }
 
   // Make sure we preserve any custom statics on the original component.
-  return hoistNonReactStatics(WithApollo, WrappedComponent);
+  return hoistNonReactStatics(WithApollo, WrappedComponent, { fetchData: true });
 };
 
 export interface OperationOption {
@@ -498,8 +498,7 @@ export default function graphql(
     if (operation.type === DocumentType.Query) (GraphQL as any).fetchData = fetchData;
 
     // Make sure we preserve any custom statics on the original component.
-    return hoistNonReactStatics(GraphQL, WrappedComponent);
-
+    return hoistNonReactStatics(GraphQL, WrappedComponent, { fetchData: true });
   };
 
 };

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -36,7 +36,7 @@ declare module 'hoist-non-react-statics' {
    *
    * Returns the target component.
    */
-  function hoistNonReactStatics(targetComponent: any, sourceComponent: any): any;
+  function hoistNonReactStatics(targetComponent: any, sourceComponent: any, customStatics: {[name: string]: boolean}): any;
   namespace hoistNonReactStatics {}
   export = hoistNonReactStatics;
 }


### PR DESCRIPTION
We were hoisting `fetchData` onto the mutation HOC, which led to the
query executing twice

Fixes #274.

Going to take a look at the open SSR issue on this branch too.