### PR TITLE
Fix issue with usage in TypeScript projects caused by 'compose' re-export

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNext
 
+- Bug: Fix issue with usage in TypeScript projects caused by 'compose' re-export. [PR #291](https://github.com/apollostack/react-apollo/pull/291)
+
 ### v0.5.12
 
 - Full support for both Apollo Client 0.4.21 and 0.5.0. [PR #277](https://github.com/apollostack/react-apollo/pull/277)

--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "lodash.isequal": "^4.1.1",
     "lodash.isobject": "^3.0.2",
     "lodash.pick": "^4.4.0",
-    "object-assign": "^4.0.1",
-    "recompose": "^0.20.2"
+    "object-assign": "^4.0.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import ApolloProvider from './ApolloProvider';
 import graphql, { withApollo } from './graphql';
 
-// expose easy way to join queries from recompose
-import compose from 'recompose/compose';
+// expose easy way to join queries from redux
+import { compose } from 'redux';
 
 export { ApolloProvider, graphql, withApollo, compose };

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -24,11 +24,6 @@ declare module 'lodash.pick' {
   export = main;
 }
 
-declare module 'recompose/compose' {
-  function hoc(component: any): any;
-  export default (...hocs) => hoc;
-}
-
 declare module 'hoist-non-react-statics' {
   /**
    * Copies any static properties present on `source` to `target`, excluding those that are specific


### PR DESCRIPTION
Fixes #279 

As suggested by @migueloller `compose` is re-exported from `redux` instead of `recompose`, since implementation is completely the same, that's why we can drop depending on `recompose` completely.

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion

