### PR TITLE
Better packaging

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,17 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNext
 
+#### Breaking
+```js
+// old
+import { getDataFromTree, renderToStringWithData } from 'react-apollo/server'
+
+// new
+import { getDataFromTree, renderToStringWithData } from 'react-apollo'
+```
+
+- Feature: Better packaging [PR #301](https://github.com/apollostack/react-apollo/pull/301)
+
 ### v0.5.15
 - Feature: Added test utilities and examples to library.
 

--- a/examples/create-react-app/src/App.js
+++ b/examples/create-react-app/src/App.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import ApolloClient, { createNetworkInterface } from 'apollo-client';
-import { ApolloProvider } from "../../../lib/src";
+import { ApolloProvider } from "../../../lib";
 
 import Pokemon from "./Pokemon";
 

--- a/examples/create-react-app/src/Pokemon.js
+++ b/examples/create-react-app/src/Pokemon.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import gql from 'graphql-tag';
-import { graphql } from '../../../lib/src';
+import { graphql } from '../../../lib';
 
 // The data prop, which is provided by the wrapper below contains,
 // a `loading` key while the query is in flight and posts when it is ready

--- a/examples/create-react-app/src/Pokemon.test.js
+++ b/examples/create-react-app/src/Pokemon.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { MockedProvider } from '../../../lib/src/test-utils';
+import { MockedProvider } from '../../../lib/test-utils';
 import { print } from 'graphql-tag/printer';
 import { addTypenameToDocument } from 'apollo-client/queries/queryTransform';
 

--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
   "name": "react-apollo",
   "version": "0.5.16",
   "description": "React data container for Apollo Client",
-  "main": "index.js",
-  "typings": "index.d.ts",
+  "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
   "scripts": {
     "test": "jest",
     "flow": "flow; test $? -eq 0 -o $? -eq 2",
     "posttest": "npm run lint",
     "filesize": "npm run compile:browser && ./scripts/filesize.js --file=./dist/index.min.js --maxGzip=15",
     "compile": "tsc",
-    "compile:browser": "rm -rf ./dist && mkdir ./dist && browserify ./lib/src/index.js --i react --i apollo-client -o=./dist/index.js && npm run minify:browser",
+    "compile:browser": "rm -rf ./dist && mkdir ./dist && browserify ./lib/index.js -t bpb -t unreachable-branch-transform --i react --i apollo-client -o=./dist/index.js && npm run minify:browser",
     "minify:browser": "uglifyjs --compress --mangle --screw-ie8 -o=./dist/index.min.js -- ./dist/index.js",
     "watch": "tsc -w",
     "lint": "tslint 'src/*.ts*' && tslint 'test/*.ts*'"
@@ -48,6 +48,15 @@
     "collectCoverage": true
   },
   "license": "MIT",
+  "files": [
+    "dist",
+    "lib",
+    "src",
+    "exports.d.ts",
+    "CHANGELOG.md",
+    "LICENSE",
+    "README.md"
+  ],
   "peerDependencies": {
     "apollo-client": "^0.4.21 || ^0.5.0",
     "react": "0.14.x || 15.* || ^15.0.0",
@@ -73,6 +82,7 @@
     "apollo-client": "0.5.0-1",
     "babel-jest": "^14.1.0",
     "babel-preset-react-native": "^1.9.0",
+    "bpb": "^0.2.2",
     "browserify": "^13.0.0",
     "cheerio": "^0.20.0",
     "colors": "^1.1.2",
@@ -109,7 +119,8 @@
     "typescript": "^2.0.3",
     "typescript-require": "^0.2.9-1",
     "typings": "^0.7.9",
-    "uglify-js": "^2.6.2"
+    "uglify-js": "^2.6.2",
+    "unreachable-branch-transform": "^0.5.1"
   },
   "dependencies": {
     "hoist-non-react-statics": "^1.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,17 @@ import graphql, { withApollo } from './graphql';
 // expose easy way to join queries from redux
 import { compose } from 'redux';
 
-export { ApolloProvider, graphql, withApollo, compose };
+export {
+  ApolloProvider,
+  graphql,
+  withApollo,
+  compose,
+};
+
+// Handle server-specific exports separately to not expose them in browser build
+if (!process.browser) {
+  const server = require('./server'); // tslint:disable-line
+
+  exports.getDataFromTree = server.getDataFromTree;
+  exports.renderToStringWithData = server.renderToStringWithData;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "sourceMap": true,
     "declaration": true,
     "noImplicitAny": false,
-    "rootDir": ".",
+    "rootDir": "src",
     "outDir": "lib",
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,5 +1,10 @@
 /// <reference path="./node_modules/typed-graphql/graphql.d.ts" />
 
+declare namespace NodeJS {
+  interface Process {
+    browser: boolean;
+  }
+}
 
 /*
   LODASH


### PR DESCRIPTION
Provide compiled sources from 'lib' for node modules. Provide all API exports from index.js.

This is breaking change. 

As a side effect this change fixes file paths in Stack Traces when react-apollo throws exceptions.