### PR TITLE
Refactor ssr

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "jest": "^16.1.0-alpha.691b0e22",
     "jest-react-native": "^16.1.0-alpha.691b0e22",
     "jsdom": "^8.3.1",
+    "lodash": "^4.16.6",
     "minimist": "^1.2.0",
     "mobx": "^2.4.2",
     "mobx-react": "^3.5.4",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
   "jest": {
     "preset": "jest-react-native",
     "testEnvironment": "jsdom",
-    "scriptPreprocessor": "preprocessor.js",
+    "transform": {
+      ".*": "preprocessor.js"
+    },
     "moduleFileExtensions": [
       "ts",
       "tsx",
@@ -91,12 +93,12 @@
     "mobx": "^2.4.2",
     "mobx-react": "^3.5.4",
     "pretty-bytes": "^3.0.1",
-    "react": "15.4.0-rc.4",
-    "react-addons-test-utils": "15.4.0-rc.4",
-    "react-dom": "15.4.0-rc.4",
+    "react": "15.3.2",
+    "react-addons-test-utils": "15.3.2",
+    "react-dom": "15.3.2",
     "react-native": "^0.36.0",
     "react-redux": "^4.4.5",
-    "react-test-renderer": "15.4.0-rc.4",
+    "react-test-renderer": "15.3.2",
     "redux": "^3.5.2",
     "redux-form": "^6.0.5",
     "redux-immutable": "^3.0.7",

--- a/src/server.ts
+++ b/src/server.ts
@@ -48,6 +48,9 @@ export function walkTree(
     //   https://github.com/facebook/react/blob/master/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js#L66
     if (Component.prototype && Component.prototype.isReactComponent) {
       const instance = new Component(props, context);
+      // In case the user doesn't pass these to super in the constructor
+      instance.props = instance.props || props;
+      instance.context = instance.context || context;
 
       // Override setState to just change the state, not queue up an update.
       //   (we can't do the default React thing as we aren't mounted "properly"
@@ -63,7 +66,6 @@ export function walkTree(
         instance.componentWillMount();
       }
 
-
       if (instance.getChildContext) {
         childContext = assign({}, context, instance.getChildContext());
       }
@@ -73,12 +75,15 @@ export function walkTree(
       child = Component(props, context);
     }
 
-    walkTree(child, childContext, visitor);
-
+    if (child) {
+      walkTree(child, childContext, visitor);
+    }
   } else { // a basic string or dom element, just get children
     if (element.props && element.props.children) {
       Children.forEach(element.props.children, (child: any) => {
-        walkTree(child, context, visitor);
+        if (child) {
+          walkTree(child, context, visitor);
+        }
       });
     }
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,6 @@ import { Children } from 'react';
 import * as ReactDOM from 'react-dom/server';
 import ApolloClient from 'apollo-client';
 import assign = require('object-assign');
-import flatten = require('lodash.flatten');
 
 
 declare interface Context {
@@ -13,107 +12,127 @@ declare interface Context {
 }
 
 declare interface QueryTreeArgument {
-  component: any;
-  queries?: any[];
-  context?: Context;
+  rootElement: any;
+  rootContext?: Context;
 }
 
-export function getPropsFromChild(child) {
-  const { props, type } = child;
-  let ownProps = assign({}, props);
-  if (type && type.defaultProps) ownProps = assign({}, type.defaultProps, props);
-  return ownProps;
+declare interface QueryResult {
+  query: Promise<any>;
+  element: any;
+  context: any;
 }
 
-export function getChildFromComponent(component) {
-  // See if this is a class, or stateless function
-  if (component && component.render) return component.render();
-  return component;
-}
-
-let contextStore = {};
-function getQueriesFromTree(
-  { component, context = {}, queries = []}: QueryTreeArgument, fetch: boolean = true
+// Recurse an React Element tree, running visitor on each element.
+// If visitor returns `false`, don't call the element's render function
+//   or recurse into it's child elements
+export function walkTree(
+  element: any,
+  context: any,
+  visitor: (element: any, context: any) => boolean | void
 ) {
-  contextStore = assign({}, contextStore, context);
-  if (!component) return;
+  // console.log(element)
+  const shouldContinue = visitor(element, context);
 
-  // stateless function
-  if (typeof component === 'function') component = { type: component };
-  const { type, props } = component;
-
-  if (typeof type === 'function') {
-    let ComponentClass = type;
-    let ownProps = getPropsFromChild(component);
-    const Component = new ComponentClass(ownProps, context);
-    try {
-      Component.props = ownProps;
-      Component.context = context;
-      Component.setState = (newState: any) => {
-        Component.state = assign({}, Component.state, newState);
-      };
-    } catch (e) {} // tslint:disable-line
-    if (Component.componentWillMount) Component.componentWillMount();
-
-    let newContext = context;
-    if (Component.getChildContext) newContext = assign({}, context, Component.getChildContext());
-
-    // see if there is a fetch data method
-    if (typeof type.fetchData === 'function' && fetch) {
-      const query = type.fetchData(ownProps, newContext);
-      if (query) queries.push({ query, component });
-    }
-
-    getQueriesFromTree({
-      component: getChildFromComponent(Component),
-      context: newContext,
-      queries,
-    });
-  } else if (props && props.children) {
-    Children.forEach(props.children, (child: any) => getQueriesFromTree({
-      component: child,
-      context,
-      queries,
-    }));
+  if (shouldContinue === false) {
+    return;
   }
 
-  return { queries, context: contextStore };
+  const Component = element.type;
+  // a stateless functional component or a class
+  if (typeof Component === 'function') {
+    const props = assign({}, Component.defaultProps, element.props);
+    let childContext = context;
+    let child;
+
+    // Are we are a react class?
+    //   https://github.com/facebook/react/blob/master/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js#L66
+    if (Component.prototype && Component.prototype.isReactComponent) {
+      const instance = new Component(props, context);
+
+      // Override setState to just change the state, not queue up an update.
+      //   (we can't do the default React thing as we aren't mounted "properly"
+      //   however, we don't need to re-render as well only support setState in
+      //   componentWillMount, which happens *before* render).
+      instance.setState = (newState) => {
+        instance.state = assign({}, instance.state, newState);
+      };
+
+      // this is a poor man's version of
+      //   https://github.com/facebook/react/blob/master/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js#L181
+      if (instance.componentWillMount) {
+        instance.componentWillMount();
+      }
+
+
+      if (instance.getChildContext) {
+        childContext = assign({}, context, instance.getChildContext());
+      }
+
+      child = instance.render();
+    } else { // just a stateless functional
+      child = Component(props, context);
+    }
+
+    walkTree(child, childContext, visitor);
+
+  } else { // a basic string or dom element, just get children
+    if (element.props && element.props.children) {
+      Children.forEach(element.props.children, (child: any) => {
+        walkTree(child, context, visitor);
+      });
+    }
+  }
+}
+
+function getQueriesFromTree(
+  { rootElement, rootContext = {} }: QueryTreeArgument, fetchRoot: boolean = true
+): QueryResult[] {
+  const queries = [];
+
+  walkTree(rootElement, rootContext, (element, context) => {
+    const Component = element.type || element;
+
+    const skipRoot = !fetchRoot && (element === rootElement);
+    if (typeof Component.fetchData === 'function' && !skipRoot) {
+      const props = assign({}, Component.defaultProps, element.props);
+      const query = Component.fetchData(props, context);
+      if (query) {
+        queries.push({ query, element, context });
+
+        // Tell walkTree to not recurse inside this component;  we will
+        // wait for the query to execute before attempting it.
+        return false;
+      }
+    }
+  });
+
+  return queries;
 }
 
 // XXX component Cache
-export function getDataFromTree(app, ctx: any = {}, fetch: boolean = true): Promise<any> {
+export function getDataFromTree(rootElement, rootContext: any = {}, fetchRoot: boolean = true): Promise<void> {
 
-  // reset for next loop
-  contextStore = {};
-  let { context, queries } = getQueriesFromTree({ component: app, context: ctx }, fetch);
-  // reset for next loop
-  contextStore = {};
+  let queries = getQueriesFromTree({ rootElement, rootContext }, fetchRoot);
 
   // no queries found, nothing to do
-  if (!queries.length) return Promise.resolve(context);
+  if (!queries.length) return Promise.resolve();
 
-  const mappedQueries = flatten(queries).map(y => y.query.then(x => y));
-  // run through all queries we can
-  return Promise.all(mappedQueries)
-    .then(trees => Promise.all(trees.filter(x => !!x).map((x: any) => {
-      return getDataFromTree(x.component, context, false); // don't rerun `fetchData'
-    })))
-    .then(() => (context));
-
+  // wait on each query that we found, re-rendering the subtree when it's done
+  const mappedQueries = queries.map(({ query, element, context }) =>  {
+    // we've just grabbed the query for element, so don't try and get it again
+    return query.then(_ => getDataFromTree(element, context, false));
+  });
+  return Promise.all(mappedQueries).then(_ => null);
 }
 
 export function renderToStringWithData(component) {
   return getDataFromTree(component)
-    .then(({ client }) => {
-      let markup = ReactDOM.renderToString(component);
-      let apolloState = client.queryManager.getApolloState();
+    .then(() => ReactDOM.renderToString(component));
+}
 
-      for (let queryId in apolloState.queries) {
-        let fieldsToNotShip = ['minimizedQuery', 'minimizedQueryString'];
-        for (let field of fieldsToNotShip) delete apolloState.queries[queryId][field];
-      }
-
-      // it's OK, because apolloState is nested somewhere in globalState
-      return { markup, initialState: client.store.getState() };
-    });
+export function cleanupApolloState(apolloState) {
+  for (let queryId in apolloState.queries) {
+    let fieldsToNotShip = ['minimizedQuery', 'minimizedQueryString'];
+    for (let field of fieldsToNotShip) delete apolloState.queries[queryId][field];
+  }
 }

--- a/test/react-web/server/index.test.tsx
+++ b/test/react-web/server/index.test.tsx
@@ -41,6 +41,13 @@ describe('SSR', () => {
         expect(elementCount).toEqual(5);
       });
 
+      it('basic element trees with nulls', () => {
+        let elementCount = 0;
+        const rootElement = <div>{null}</div>;
+        walkTree(rootElement, {}, (element) => { elementCount += 1 });
+        expect(elementCount).toEqual(1);
+      });
+
       it('functional stateless components', () => {
         let elementCount = 0;
         const MyComponent = ({ n }) => <div>{_.times(n, (i) => <span key={i} />)}</div>;
@@ -57,9 +64,50 @@ describe('SSR', () => {
         expect(elementCount).toEqual(9);
       });
 
+      it('functional stateless components with null children', () => {
+        let elementCount = 0;
+        const MyComponent = ({ n, children=null }) =>
+          <div>{_.times(n, (i) => <span key={i} />)}{children}</div>;
+        walkTree(<MyComponent n={5}>{null}</MyComponent>, {},
+          (element) => { elementCount += 1 });
+        expect(elementCount).toEqual(7);
+      });
+
+      it('functional stateless components that render null', () => {
+        let elementCount = 0;
+        const MyComponent = () => null;
+        walkTree(<MyComponent/>, {}, (element) => { elementCount += 1 });
+        expect(elementCount).toEqual(1);
+      });
+
       it('basic classes', () => {
         let elementCount = 0;
         class MyComponent extends React.Component<any, any> {
+          render() {
+            return <div>{_.times(this.props.n, (i) => <span key={i} />)}</div>;
+          }
+        }
+        walkTree(<MyComponent n={5}/>, {}, (element) => { elementCount += 1 });
+        expect(elementCount).toEqual(7);
+      });
+
+      it('basic classes components that render null', () => {
+        let elementCount = 0;
+        class MyComponent extends React.Component<any, any> {
+          render() {
+            return null;
+          }
+        }
+        walkTree(<MyComponent/>, {}, (element) => { elementCount += 1 });
+        expect(elementCount).toEqual(1);
+      });
+
+      it('basic classes with incomplete constructors', () => {
+        let elementCount = 0;
+        class MyComponent extends React.Component<any, any> {
+          constructor() {
+            super(); // note doesn't pass props or context
+          }
           render() {
             return <div>{_.times(this.props.n, (i) => <span key={i} />)}</div>;
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2453,7 +2453,7 @@ fbjs-scripts@^0.7.0:
     semver "^5.1.0"
     through2 "^2.0.0"
 
-fbjs@^0.8.1, fbjs@^0.8.3, fbjs@^0.8.4:
+fbjs@^0.8.3, fbjs@^0.8.4:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.5.tgz#f69ba8a876096cb1b9bffe4d7c1e71c19d39d008"
   dependencies:
@@ -5143,9 +5143,9 @@ rc@^1.0.1, rc@^1.1.2, rc@^1.1.5, rc@^1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~1.0.4"
 
-react-addons-test-utils@15.4.0-rc.4:
-  version "15.4.0-rc.4"
-  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.4.0-rc.4.tgz#90a29630bacb6964ca907a0f7c6a447a0e5625e1"
+react-addons-test-utils@15.3.2:
+  version "15.3.2"
+  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.3.2.tgz#c09a44f583425a4a9c1b38444d7a6c3e6f0f41f6"
 
 react-clone-referenced-element@^1.0.1:
   version "1.0.1"
@@ -5155,13 +5155,9 @@ react-deep-force-update@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.0.1.tgz#f911b5be1d2a6fe387507dd6e9a767aa2924b4c7"
 
-react-dom@15.4.0-rc.4:
-  version "15.4.0-rc.4"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.0-rc.4.tgz#e95bbe99d47aeefd60bad9a0502ca926283d960a"
-  dependencies:
-    fbjs "^0.8.1"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.0"
+react-dom@15.3.2:
+  version "15.3.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.3.2.tgz#c46b0aa5380d7b838e7a59c4a7beff2ed315531f"
 
 react-native@^0.36.0:
   version "0.36.0"
@@ -5255,9 +5251,9 @@ react-redux@^4.4.5:
     lodash "^4.2.0"
     loose-envify "^1.1.0"
 
-react-test-renderer@15.4.0-rc.4:
-  version "15.4.0-rc.4"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.4.0-rc.4.tgz#49ee184c0bb50195f8f588f452dc6f0dbc735f40"
+react-test-renderer@15.3.2:
+  version "15.3.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.3.2.tgz#d8f083d37d2d41e97bbdc26a1dd9282f0baf7857"
 
 react-timer-mixin@^0.13.2:
   version "0.13.3"
@@ -5270,9 +5266,9 @@ react-transform-hmr@^1.0.4:
     global "^4.3.0"
     react-proxy "^1.1.7"
 
-react@15.4.0-rc.4:
-  version "15.4.0-rc.4"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.4.0-rc.4.tgz#09d08dd266a9088db963399dfdf814377e9a74dc"
+react@15.3.2:
+  version "15.3.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.3.2.tgz#a7bccd2fee8af126b0317e222c28d1d54528d09e"
   dependencies:
     fbjs "^0.8.4"
     loose-envify "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3986,6 +3986,10 @@ lockfile@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/lockfile/-/lockfile-1.0.2.tgz#97e1990174f696cbe0a3acd58a43b84aa30c7c83"
 
+lodash:
+  version "4.16.6"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.6.tgz#d22c9ac660288f3843e16ba7d2b5d06cca27d777"
+
 lodash-es@^4.12.0, lodash-es@^4.2.1:
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.16.4.tgz#4dc3e2cf33a8c343028aa7f7e06d1c9697042599"


### PR DESCRIPTION
Refactored SSR to use a slightly more principled `walkTree` method.

Tests pass, some points of interest:

1. I got rid of returning the `context` from the SSR functions. This seemed kind of undefined (what was it? The lowest context we saw in the tree? Should we have been just picking the first `ApolloProvider` child context we saw?). All in all it seemed a bit hacky, and the user will have access to an `ApolloClient` anyway, so can't they just get the store themselves?

 - this will require a docs change.

2. I am still assigning `instance.setState`. This seems to *not* throw an exception. How does this fit your understanding @rewop? I was surprised by this but we need to do something like this to allow people to call `setState` in `componentWillMount` (or pursue a different method of rendering[1]).

3. @jbaxleyiii I wonder if rather than passing `{ element, context }` around (and calling `element.type.fetchData`, a static method), we could not just pass the `instance` around, and call `instance.fetchData`? It would make the code a little simpler in `server.js`, but also it would make `graphql.js` a bit simpler too. Is there a reason to *not* instanciate the element on the server before running the query?

[1] I feel like ultimately we should be trying to use React's rendering infrastructure, as although this is no doubt quicker, it feels really brittle and wouldn't be surprised if there's lots of things you can do that break it.