### PR TITLE
gets rid of queries.test warning

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 1 or 2 months), so that we can take advantage of SemVer to signify breaking changes from that point on.
 
 ### vNext
++ [PR #390](https://github.com/apollostack/react-apollo/pull/390) gets rid of warning during queries test.
 
 ### v0.7.2
 

--- a/test/react-web/client/graphql/queries.test.tsx
+++ b/test/react-web/client/graphql/queries.test.tsx
@@ -2021,8 +2021,7 @@ describe('queries', () => {
          return null;
        }
      };
-
-     mount(<ApolloProvider client={client}><Container /></ApolloProvider>);
+     const output = renderer.create(<ApolloProvider client={client}><Container /></ApolloProvider>);
   });
 
   it('stores the component name in the query metadata', (done) => {


### PR DESCRIPTION
This just gets rid of warning on the queries.test.

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x ] Make sure all of the significant new logic is covered by tests
- [ x] Rebase your changes on master so that they can be merged easily
- [ x] Make sure all tests and linter rules pass
- [ x] Update CHANGELOG.md with your change
- [ ] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
