### PR TITLE
Silently catch errors for changing variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "react-native": "^0.38.0",
     "react-redux": "^4.4.5",
     "react-test-renderer": "15.4.0-rc.4",
+    "recompose": "^0.21.2",
     "redux": "^3.5.2",
     "redux-form": "^6.0.5",
     "redux-immutable": "^3.0.7",

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -338,7 +338,12 @@ export default function graphql(
           this.queryObservable._setOptionsNoResult(opts);
         } else {
           if (this.queryObservable.setOptions) {
-            this.queryObservable.setOptions(opts);
+            this.queryObservable.setOptions(opts)
+              // The error will be passed to the child container, so we don't
+              // need to log it here. We could concievably log something if
+              // an option was set. OTOH we don't log errors w/ the original
+              // query. See https://github.com/apollostack/react-apollo/issues/404
+              .catch((error) => null);
           }
         }
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,10 +20,6 @@
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.8.5.tgz#3f06ab58a5f37a94c94fafe0767efa0fcd0e7b3a"
 
-"@types/immutable@^3.8.3":
-  version "3.8.6"
-  resolved "https://registry.yarnpkg.com/@types/immutable/-/immutable-3.8.6.tgz#3612786c3c5ba4084cc9bf18b7eaf925438a00e5"
-
 "@types/invariant@^2.2.27":
   version "2.2.28"
   resolved "https://registry.yarnpkg.com/@types/invariant/-/invariant-2.2.28.tgz#ad721b5c0168db3aaffe551d4acfb8a5b4386e30"
@@ -196,7 +192,7 @@ any-promise@^1.0.0, any-promise@^1.1.0, any-promise@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
 
-apollo-client@0.6.0:
+apollo-client@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-0.6.0.tgz#bd46808c3c55003927a8e373686333e022097edc"
   dependencies:
@@ -1363,6 +1359,10 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+change-emitter@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.2.tgz#6b88ca4d5d864e516f913421b11899a860aee8db"
 
 cheerio@^0.19.0:
   version "0.19.0"
@@ -2996,7 +2996,7 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
-hoist-non-react-statics@^1.0.3, hoist-non-react-statics@^1.0.5, hoist-non-react-statics@^1.2.0:
+hoist-non-react-statics@^1.0.0, hoist-non-react-statics@^1.0.3, hoist-non-react-statics@^1.0.5, hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
 
@@ -5128,9 +5128,9 @@ react-deep-force-update@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.0.1.tgz#f911b5be1d2a6fe387507dd6e9a767aa2924b4c7"
 
-react-dom@15.4.0-rc.2:
-  version "15.4.0-rc.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.0-rc.2.tgz#a9dd33a076d0db4ab77101a4b3add4b8378b29de"
+"react-dom@0.14.x || 15.* || ^15.0.0":
+  version "15.4.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.2.tgz#015363f05b0a1fd52ae9efdd3a0060d90695208f"
   dependencies:
     fbjs "^0.8.1"
     loose-envify "^1.1.0"
@@ -5346,6 +5346,15 @@ recast@^0.11.17:
     esprima "~3.1.0"
     private "~0.1.5"
     source-map "~0.5.0"
+
+recompose@^0.21.2:
+  version "0.21.2"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.21.2.tgz#ff3fbdb2397b1c77c47d451be2a63b9295d44681"
+  dependencies:
+    change-emitter "^0.1.2"
+    fbjs "^0.8.1"
+    hoist-non-react-statics "^1.0.0"
+    symbol-observable "^1.0.4"
 
 redent@^1.0.0:
   version "1.0.0"
@@ -5977,7 +5986,7 @@ swapi-graphql@0.0.4:
     graphql-relay "0.3.6"
     isomorphic-fetch "2.2.1"
 
-symbol-observable@^1.0.2:
+symbol-observable@^1.0.2, symbol-observable@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 


### PR DESCRIPTION
Mirror the behaviour for the original query, which is to pass the error via the `error` prop, not let a promise exception reach the top of the stack.

https://github.com/apollostack/react-apollo/issues/404