### PR TITLE
withRef option for withApollo HoC

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@ Expect active development and potentially significant breaking changes in the `0
 ### vNext
 - Bug: [Issue #404](https://github.com/apollostack/react-apollo/issues/404) fix issue with network errors thrown when changing variables.
 
+- Feature: Allow access to `withApollo`'s wrapped instance thanks to `{withRef: true}` option [Issue #331](https://github.com/apollostack/react-apollo/issues/331).
+
 ### 0.8.2
 - Chore: [PR #403](https://github.com/apollostack/react-apollo/pull/403) move react-dom to be an optional dependency for better react-native builds.
 

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -76,7 +76,10 @@ function getDisplayName(WrappedComponent) {
 // Helps track hot reloading.
 let nextVersion = 0;
 
-export function withApollo(WrappedComponent) {
+export function withApollo(
+  WrappedComponent,
+  operationOptions: OperationOption = {}
+) {
 
   const withDisplayName = `withApollo(${getDisplayName(WrappedComponent)})`;
 
@@ -100,10 +103,19 @@ export function withApollo(WrappedComponent) {
 
     }
 
+    getWrappedInstance() {
+      invariant(operationOptions.withRef,
+        `To access the wrapped instance, you need to specify ` +
+        `{ withRef: true } in the options`
+      );
+
+      return (this.refs as any).wrappedInstance;
+    }
 
     render() {
       const props = assign({}, this.props);
       props.client = this.client;
+      if (operationOptions.withRef) props.ref = 'wrappedInstance';
       return createElement(WrappedComponent, props);
     }
   }

--- a/test/react-web/client/graphql/shared-operations.test.tsx
+++ b/test/react-web/client/graphql/shared-operations.test.tsx
@@ -30,6 +30,38 @@ describe('shared operations', () => {
 
       renderer.create(<ApolloProvider client={client}><ContainerWithData /></ApolloProvider>);
     });
+    
+    it('allows a way to access the wrapped component instance', () => {
+      
+      const client = new ApolloClient();
+      
+      const testData = { foo: 'bar' };
+      
+      class Container extends React.Component<any, any> {
+        someMethod() {
+          return testData;
+        }
+
+        render() {
+          return <span></span>;
+        }
+      }
+
+      const Decorated = withApollo(Container, { withRef: true });
+
+      const tree = TestUtils.renderIntoDocument(
+        <ApolloProvider client={client}>
+          <Decorated />
+        </ApolloProvider>
+      ) as any;
+
+      const decorated = TestUtils.findRenderedComponentWithType(tree, Decorated);
+
+      expect(() => (decorated as any).someMethod()).toThrow();
+      expect((decorated as any).getWrappedInstance().someMethod()).toEqual(testData);
+      expect((decorated as any).refs.wrappedInstance.someMethod()).toEqual(testData);
+
+    });
   });
 
   it('binds two queries to props', () => {


### PR DESCRIPTION
Issue #331.

Re-using the `graphql`'s `OperationOption` interface only for its `withRef` option may not make a lot of sense?

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
