### PR TITLE
Add an `alias` option to `graphql` container

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ Expect active development and potentially significant breaking changes in the `0
 
 - Feature: Allow access to `withApollo`'s wrapped instance thanks to `{withRef: true}` option [Issue #331](https://github.com/apollostack/react-apollo/issues/331).
 
+- Feature: Add an `alias` option to the `graphql` function to allow customizing the display name of the wrapped component ([Issue #354](https://github.com/apollostack/react-apollo/issues/354)).
+
 ### 0.8.2
 - Chore: [PR #403](https://github.com/apollostack/react-apollo/pull/403) move react-dom to be an optional dependency for better react-native builds.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Use your GraphQL server data in your React components, with the [Apollo Client](
 
 Documentation for this client can be found [here](http://docs.apollostack.com/apollo-client/react.html);
 
+### Local Development
+
+If you'd like to run a local copy of this package, you can follow these steps:
+
+- Clone this repo locally.
+- In your local `react-apollo` directory: `npm link` then `npm run compile`.
+- In your app's directory: `npm link react-apollo`.
+
 ## Install
 
 ```bash

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -37,6 +37,7 @@ export declare interface MutationOptions {
   optimisticResponse?: Object;
   updateQueries?: MutationQueryReducersMap;
   forceFetch?: boolean;
+  alias?: string;
 }
 
 export declare interface QueryOptions {
@@ -47,6 +48,7 @@ export declare interface QueryOptions {
   noFetch?: boolean;
   pollInterval?: number;
   fragments?: FragmentDefinitionNode[] | FragmentDefinitionNode[][];
+  alias?: string;
   // deprecated
   skip?: boolean;
 }
@@ -156,7 +158,7 @@ export default function graphql(
   const version = nextVersion++;
   return function wrapWithApolloComponent(WrappedComponent) {
 
-    const graphQLDisplayName = `Apollo(${getDisplayName(WrappedComponent)})`;
+    const graphQLDisplayName = `${mapPropsToOptions({}).alias || `Apollo`}(${getDisplayName(WrappedComponent)})`;
 
     class GraphQL extends Component<any, any> {
       static displayName = graphQLDisplayName;

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -37,7 +37,6 @@ export declare interface MutationOptions {
   optimisticResponse?: Object;
   updateQueries?: MutationQueryReducersMap;
   forceFetch?: boolean;
-  alias?: string;
 }
 
 export declare interface QueryOptions {
@@ -48,7 +47,6 @@ export declare interface QueryOptions {
   noFetch?: boolean;
   pollInterval?: number;
   fragments?: FragmentDefinitionNode[] | FragmentDefinitionNode[][];
-  alias?: string;
   // deprecated
   skip?: boolean;
 }
@@ -133,6 +131,7 @@ export interface OperationOption {
   name?: string;
   withRef?: boolean;
   shouldResubscribe?: (props: any, nextProps: any) => boolean;
+  alias?: string;
 }
 
 export default function graphql(
@@ -141,7 +140,7 @@ export default function graphql(
 ) {
 
   // extract options
-  const { options = defaultMapPropsToOptions, skip = defaultMapPropsToSkip } = operationOptions;
+  const { options = defaultMapPropsToOptions, skip = defaultMapPropsToSkip, alias = 'Apollo' } = operationOptions;
 
   let mapPropsToOptions = options as (props: any) => QueryOptions | MutationOptions;
   if (typeof mapPropsToOptions !== 'function') mapPropsToOptions = () => options;
@@ -158,7 +157,7 @@ export default function graphql(
   const version = nextVersion++;
   return function wrapWithApolloComponent(WrappedComponent) {
 
-    const graphQLDisplayName = `${mapPropsToOptions({}).alias || `Apollo`}(${getDisplayName(WrappedComponent)})`;
+    const graphQLDisplayName = `${alias}(${getDisplayName(WrappedComponent)})`;
 
     class GraphQL extends Component<any, any> {
       static displayName = graphQLDisplayName;


### PR DESCRIPTION
As explained in https://github.com/apollostack/react-apollo/issues/354, your React component tree can get quite confusing when you have many nested `Apollo(...)` containers. This PR adds an `alias` option to the `graphql` HoC factory function:

```
options(ownProps) {
        return {
          alias: 'withCurrentUser',
        };
      },
```

Before:

![https://d3vv6lp55qjaqc.cloudfront.net/items/0T3a352D3f2S0B0I1N1f/Screen%20Shot%202017-01-12%20at%2016.37.00.png?X-CloudApp-Visitor-Id=be6b2112ac44aa0ca58d2b5babe73626&v=26b9d644](https://d3vv6lp55qjaqc.cloudfront.net/items/0T3a352D3f2S0B0I1N1f/Screen%20Shot%202017-01-12%20at%2016.37.00.png?X-CloudApp-Visitor-Id=be6b2112ac44aa0ca58d2b5babe73626&v=26b9d644)

After: 

![https://d3vv6lp55qjaqc.cloudfront.net/items/3E2W1J0O3H3U3N2j1l3V/Screen%20Shot%202017-01-12%20at%2017.01.40.png?X-CloudApp-Visitor-Id=be6b2112ac44aa0ca58d2b5babe73626&v=70e00ab8](https://d3vv6lp55qjaqc.cloudfront.net/items/3E2W1J0O3H3U3N2j1l3V/Screen%20Shot%202017-01-12%20at%2017.01.40.png?X-CloudApp-Visitor-Id=be6b2112ac44aa0ca58d2b5babe73626&v=70e00ab8)

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [ ] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
